### PR TITLE
Set module for each db session created

### DIFF
--- a/bin/check-oracle-query.rb
+++ b/bin/check-oracle-query.rb
@@ -50,6 +50,11 @@ class CheckOracleQuery < Sensu::Plugin::Check::CLI
          short: '-d DATABASE',
          long: '--database DATABASE'
 
+  option :module
+         description: 'Module that the oracle sessions will use'
+         short: '-m'
+         long: '--module MODULE'
+
   option :privilege,
          description: 'Connect to Oracle database by optional priviledge' \
                       ' (SYSDBA, SYSOPER, SYSASM,  , SYSDG or SYSKM)',
@@ -148,7 +153,8 @@ class CheckOracleQuery < Sensu::Plugin::Check::CLI
     session = SensuPluginsOracle::Session.new(username: config[:username],
                                               password: config[:password],
                                               database: config[:database],
-                                              privilege: config[:privilege])
+                                              privilege: config[:privilege],
+                                              module: config[:module])
 
     if session.query(config[:query].to_s)
       method, message = session.handle_query_result(config)

--- a/bin/check-oracle-query.rb
+++ b/bin/check-oracle-query.rb
@@ -50,9 +50,9 @@ class CheckOracleQuery < Sensu::Plugin::Check::CLI
          short: '-d DATABASE',
          long: '--database DATABASE'
 
-  option :module
-         description: 'Module that the oracle sessions will use'
-         short: '-m'
+  option :module,
+         description: 'Module that the oracle sessions will use',
+         short: '-m',
          long: '--module MODULE'
 
   option :privilege,
@@ -166,7 +166,8 @@ class CheckOracleQuery < Sensu::Plugin::Check::CLI
   end
 
   def handle_connections_from_file
-    sessions = ::SensuPluginsOracle::Session.parse_from_file(config[:file])
+    sessions = ::SensuPluginsOracle::Session.parse_from_file(config[:file],
+                                                             config[:module])
     ::SensuPluginsOracle::Session.handle_multiple(sessions: sessions,
                                                   method: :query,
                                                   config: config,

--- a/lib/sensu-plugins-oracle/session.rb
+++ b/lib/sensu-plugins-oracle/session.rb
@@ -5,7 +5,7 @@ module SensuPluginsOracle
   class Session
     attr_reader :name, :error_message
     attr_reader :connect_string
-    attr_reader :username, :password, :database, :priviledge
+    attr_reader :username, :password, :database, :module, :priviledge
 
     attr_reader :server_version
 
@@ -34,6 +34,7 @@ module SensuPluginsOracle
       @password = args[:password]
       @database = args[:database]
       @priviledge = validate_priviledge(args[:priviledge])
+      @module = args[:module]
       @provide_name_in_result = args[:provide_name_in_result] || false
     end
 
@@ -175,7 +176,15 @@ module SensuPluginsOracle
       else
         @connection = OCI8.new(@connect_string.to_s)
       end
+
+      set_session_module
     end
+
+    def set_session_module
+      if ! @module
+        return
+      @connection.exec("call DBMS_APPLICATION_INFO.SET_MODULE ('%s', null)" % @module.to_s)
+
 
     def disconnect
       @connection.logoff if @connection

--- a/lib/sensu-plugins-oracle/session.rb
+++ b/lib/sensu-plugins-oracle/session.rb
@@ -184,7 +184,7 @@ module SensuPluginsOracle
       if ! @module
         return
       @connection.exec("call DBMS_APPLICATION_INFO.SET_MODULE ('%s', null)" % @module.to_s)
-
+    end
 
     def disconnect
       @connection.logoff if @connection

--- a/lib/sensu-plugins-oracle/session.rb
+++ b/lib/sensu-plugins-oracle/session.rb
@@ -38,7 +38,7 @@ module SensuPluginsOracle
       @provide_name_in_result = args[:provide_name_in_result] || false
     end
 
-    def self.parse_from_file(file)
+    def self.parse_from_file(file, db_module)
       sessions = []
 
       File.read(file).each_line do |line|
@@ -47,7 +47,8 @@ module SensuPluginsOracle
         a = line.split(/:|,|;/)
         sessions << Session.new(name: a[0],
                                 connect_string: a[1],
-                                provide_name_in_result: true)
+                                provide_name_in_result: true,
+                                module: db_module)
       end
 
       sessions
@@ -181,7 +182,7 @@ module SensuPluginsOracle
     end
 
     def set_session_module
-      return if !@module        
+      return if !@module
 
       @connection.exec("call DBMS_APPLICATION_INFO.SET_MODULE ('%s', null)" % @module.to_s)
 

--- a/lib/sensu-plugins-oracle/session.rb
+++ b/lib/sensu-plugins-oracle/session.rb
@@ -181,9 +181,10 @@ module SensuPluginsOracle
     end
 
     def set_session_module
-      if ! @module
-        return
+      return if !@module        
+
       @connection.exec("call DBMS_APPLICATION_INFO.SET_MODULE ('%s', null)" % @module.to_s)
+
     end
 
     def disconnect

--- a/lib/sensu-plugins-oracle/version.rb
+++ b/lib/sensu-plugins-oracle/version.rb
@@ -1,3 +1,3 @@
 module SensuPluginsOracle
-  VERSION = '0.9.2'
+  VERSION = '0.9.1'
 end

--- a/lib/sensu-plugins-oracle/version.rb
+++ b/lib/sensu-plugins-oracle/version.rb
@@ -1,3 +1,3 @@
 module SensuPluginsOracle
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 end

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -89,7 +89,7 @@ describe SensuPluginsOracle::Session do
   context 'connection with username, password, database, and priviledges' do
 
     before(:each) do
-      @session = SensuPluginsOracle::Session.new(username: 'a', password: 'b', database: 'c', priviledge: 'SYSDBA', name: 'a_name')
+      @session = SensuPluginsOracle::Session.new(username: 'a', password: 'b', database: 'c', module: 'd', priviledge: 'SYSDBA', name: 'a_name')
     end
 
     it "creates a session" do
@@ -97,6 +97,7 @@ describe SensuPluginsOracle::Session do
       expect(@session.username).to eq('a')
       expect(@session.password).to eq('b')
       expect(@session.database).to eq('c')
+      expect(@session.database).to eq('d')
       expect(@session.priviledge).to eq(:SYSDBA)
     end
 

--- a/spec/session_spec.rb
+++ b/spec/session_spec.rb
@@ -14,12 +14,13 @@ describe SensuPluginsOracle::Session do
   context 'connect string' do
 
     before(:each) do
-      @session = SensuPluginsOracle::Session.new(connect_string: "a/b@c", name: 'a_name')
+      @session = SensuPluginsOracle::Session.new(connect_string: "a/b@c", name: 'a_name', module: 'm')
     end
 
     it "creates a session" do
       expect(@session.name).to eq('a_name')
       expect(@session.connect_string).to eq('a/b@c')
+      expect(@session.module).to eq('m')
     end
 
     it "handles invalid aliveness" do
@@ -97,7 +98,7 @@ describe SensuPluginsOracle::Session do
       expect(@session.username).to eq('a')
       expect(@session.password).to eq('b')
       expect(@session.database).to eq('c')
-      expect(@session.database).to eq('d')
+      expect(@session.module).to eq('d')
       expect(@session.priviledge).to eq(:SYSDBA)
     end
 


### PR DESCRIPTION
Hello @thomis 

Currently all the sessions created by the plugin have a module set like 'ruby@xxxx'. This makes difficult to trace the db activity of such checks.

I am looking forward for any kind suggestions.


Cheers
Florin